### PR TITLE
Fix docker_compose.yml image.

### DIFF
--- a/nutcase/docker/docker_compose.yml
+++ b/nutcase/docker/docker_compose.yml
@@ -5,7 +5,7 @@ version: '3.9'
 #========================================
 services:
   nutcase:
-    image: kronos443/nutcase:latest-beta  #  V0.3.0Beta1 # latest  # V0.2.0  # v0.2.0-beta3  # V0.2.0_Beta # apcbeta # latest
+    image: kronos443/nutcase:latest_beta  #  V0.3.0Beta1 # latest  # V0.2.0  # v0.2.0-beta3  # V0.2.0_Beta # apcbeta # latest
     container_name: NUTCase
     restart: unless-stopped  # "no" always on-failure unless-stopped    
     hostname: NUTCase


### PR DESCRIPTION
Tripped on this bug using the docker-compose.yml inside the repo. The image name is not using the correct char for the branch (dash vs underscore.)